### PR TITLE
feat(clubs): add campus life clubs query and type definitions

### DIFF
--- a/src/queries/clubs.ts
+++ b/src/queries/clubs.ts
@@ -1,0 +1,12 @@
+import clubsData from '@/data/clubs.json'
+
+/**
+ * Returns all campus life clubs from the static clubs data
+ */
+export async function clClubs(): Promise<ClClub[]> {
+    return clubsData.map((club) => ({
+        name: club.club,
+        website: club.website,
+        instagram: club.instagram,
+    }))
+}

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,6 +1,7 @@
 import { deleteUniversitySport } from '@/mutations/university-sports/delete'
 import { upsertUniversitySport } from '@/mutations/university-sports/upsert'
 import { clEvents } from '@/queries/cl-events'
+import { clClubs } from '@/queries/clubs'
 import { food } from '@/queries/food'
 import { sports } from '@/queries/sports'
 import { GraphQLScalarType, Kind } from 'graphql'
@@ -59,6 +60,7 @@ export const resolvers = {
     Query: {
         food,
         clEvents,
+        clClubs,
         appAnnouncements: appAnnouncementsQuery,
         announcements: appAnnouncementsQuery,
         universitySports: sports,

--- a/src/schema/schema.gql
+++ b/src/schema/schema.gql
@@ -11,6 +11,10 @@ type Query {
     """
     clEvents: [ClEvent!]!
     """
+    Get all campus life clubs
+    """
+    clClubs: [ClClub!]!
+    """
     Get the current announcements
     """
     announcements: [Announcement!]!

--- a/src/schema/schema.gql
+++ b/src/schema/schema.gql
@@ -13,7 +13,7 @@ type Query {
     """
     Get all campus life clubs
     """
-    clClubs: [ClClub!]!
+    clClubs: [Host!]!
     """
     Get the current announcements
     """

--- a/src/schema/types.gql
+++ b/src/schema/types.gql
@@ -293,24 +293,6 @@ type ClEvent {
 }
 
 """
-A campus life club.
-"""
-type ClClub {
-    """
-    The name of the club
-    """
-    name: String!
-    """
-    The website URL of the club (if available)
-    """
-    website: String
-    """
-    The Instagram profile URL of the club (if available)
-    """
-    instagram: String
-}
-
-"""
 Host of the event, usually a club or student group.
 """
 type Host {

--- a/src/schema/types.gql
+++ b/src/schema/types.gql
@@ -293,6 +293,24 @@ type ClEvent {
 }
 
 """
+A campus life club.
+"""
+type ClClub {
+    """
+    The name of the club
+    """
+    name: String!
+    """
+    The website URL of the club (if available)
+    """
+    website: String
+    """
+    The Instagram profile URL of the club (if available)
+    """
+    instagram: String
+}
+
+"""
 Host of the event, usually a club or student group.
 """
 type Host {

--- a/src/types/clEvents.d.ts
+++ b/src/types/clEvents.d.ts
@@ -1,3 +1,9 @@
+interface ClClub {
+    name: string
+    website: string | null
+    instagram: string | null
+}
+
 interface ClEvent {
     id: string
     organizer: string


### PR DESCRIPTION
This pull request introduces functionality to fetch and return campus life clubs data. The most important changes include adding a new query to retrieve clubs data, updating the GraphQL schema to support this new query, and integrating the query into the resolvers.

New functionality for fetching campus life clubs data:

* [`src/queries/clubs.ts`](diffhunk://#diff-6c344f71d447a7cce7f6b238ff96d747b5838485287291157155851e65a858c3R1-R12): Added a new function `clClubs` to fetch and return campus life clubs data from a static JSON file.

GraphQL schema updates:

* [`src/schema/schema.gql`](diffhunk://#diff-61997d4ebaa4be9328c53a48386491a30642ec7fea39b8719e29dd0344badacaR14-R17): Added a new query `clClubs` to the `Query` type to retrieve all campus life clubs.
* [`src/schema/types.gql`](diffhunk://#diff-06b281c004c979b2b71c3e6228072b18d8409a07dfb1c7604d470b6cda350a73R295-R312): Added a new type `ClClub` to define the structure of a campus life club.

Integration into resolvers:

* [`src/resolvers.ts`](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR4): Imported the new `clClubs` query and added it to the `Query` resolver. [[1]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR4) [[2]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR63)