### PR TITLE
feat(student-advisory): add student advisory events

### DIFF
--- a/src/queries/studentAdvisory.ts
+++ b/src/queries/studentAdvisory.ts
@@ -1,0 +1,18 @@
+import { cache } from '@/index'
+import getStudentAdvisoryEvents from '@/scraping/studentAdvisory'
+
+const CACHE_TTL_MOODLE = 60 * 60 * 12 // 12 hours
+
+export async function studentAdvisoryEvents(): Promise<StudentAdvisoryEvent[]> {
+    let studentAdvisoryEvents: StudentAdvisoryEvent[] | undefined =
+        await cache.get('studentAdvisoryEvents')
+
+    if (studentAdvisoryEvents) {
+        return studentAdvisoryEvents
+    }
+
+    studentAdvisoryEvents = await getStudentAdvisoryEvents()
+    cache.set('studentAdvisoryEvents', studentAdvisoryEvents, CACHE_TTL_MOODLE)
+
+    return studentAdvisoryEvents
+}

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -24,6 +24,7 @@ import { appAnnouncementsQuery } from './queries/appAnnouncements'
 import { careerServiceEvents } from './queries/careerService'
 import { neulandEventsQuery } from './queries/neulandEvents'
 import { roomReportsQuery } from './queries/roomReports'
+import { studentAdvisoryEvents } from './queries/studentAdvisory'
 
 const RestaurantLocation = {
     IngolstadtMensa: 'IngolstadtMensa',
@@ -63,6 +64,7 @@ export const resolvers = {
         clEvents,
         clClubs,
         careerServiceEvents,
+        studentAdvisoryEvents,
         appAnnouncements: appAnnouncementsQuery,
         announcements: appAnnouncementsQuery,
         universitySports: sports,

--- a/src/schema/schema.gql
+++ b/src/schema/schema.gql
@@ -19,6 +19,10 @@ type Query {
     """
     careerServiceEvents: [CareerServiceEvent!]!
     """
+    Get all events of the student advisory service.
+    """
+    studentAdvisoryEvents: [StudentAdvisoryEvent!]!
+    """
     Get the current announcements
     """
     announcements: [Announcement!]!

--- a/src/schema/types.gql
+++ b/src/schema/types.gql
@@ -353,6 +353,48 @@ type CareerServiceEvent {
 }
 
 """
+Student advisory Service Event data type. Information about a specific event from the student advisory service.
+"""
+type StudentAdvisoryEvent {
+    """
+    Unique identifier of the event
+    """
+    id: ID!
+    """
+    Title of the event in German
+    """
+    title: String!
+    """
+    Date of the event
+    """
+    date: DateTime!
+    """
+    Unlimited slots for the event
+    """
+    unlimitedSlots: Boolean!
+    """
+    Available slots for the event
+    """
+    availableSlots: Int
+    """
+    Total slots for the event
+    """
+    totalSlots: Int
+    """
+    Waiting list for the event
+    """
+    waitingList: Int
+    """
+    Maximum waiting list for the event
+    """
+    maxWaitingList: Int
+    """
+    URL for more information about the event
+    """
+    url: String
+}
+
+"""
 Announcement data to display on top of the apps dashboard
 """
 type Announcement {

--- a/src/scraping/studentAdvisory.ts
+++ b/src/scraping/studentAdvisory.ts
@@ -8,12 +8,12 @@ import fetchCookie, { type FetchCookieImpl } from 'fetch-cookie'
 import { GraphQLError } from 'graphql'
 import nodeFetch from 'node-fetch'
 
-const LIST_URL = 'https://moodle.thi.de/mod/booking/view.php?id=85612'
+const LIST_URL = 'https://moodle.thi.de/mod/booking/view.php?id=86853'
 
 /**
  * Fetch a list of event details.
  * @param {object} fetch Cookie-aware implementation of `fetch`
- * @returns {CareerServiceEvent[]}
+ * @returns {StudentAdvisoryEvent[]}
  */
 async function getEvents(
     fetch: FetchCookieImpl<
@@ -21,8 +21,8 @@ async function getEvents(
         nodeFetch.RequestInit,
         nodeFetch.Response
     >
-): Promise<CareerServiceEvent[]> {
-    const data: CareerServiceEvent[] = []
+): Promise<StudentAdvisoryEvent[]> {
+    const data: StudentAdvisoryEvent[] = []
     const page = await fetch(LIST_URL)
 
     const text = await page.text()
@@ -96,7 +96,7 @@ async function getEvents(
 export async function getAllEventDetails(
     username: string,
     password: string
-): Promise<CareerServiceEvent[]> {
+): Promise<StudentAdvisoryEvent[]> {
     const fetch = fetchCookie(nodeFetch)
 
     await login(fetch, username, password)
@@ -104,8 +104,8 @@ export async function getAllEventDetails(
     return getEvents(fetch)
 }
 
-export default async function getCareerServiceEvents(): Promise<
-    CareerServiceEvent[]
+export default async function getStudentAdvisoryEvents(): Promise<
+    StudentAdvisoryEvent[]
 > {
     try {
         const username = Bun.env.MOODLE_USERNAME

--- a/src/types/studentAdvisoryEvent.d.ts
+++ b/src/types/studentAdvisoryEvent.d.ts
@@ -1,0 +1,11 @@
+interface StudentAdvisoryEvent {
+    id: string
+    title: string
+    date: Date
+    unlimitedSlots: boolean
+    availableSlots: number | null
+    totalSlots: number | null
+    waitingList: number | null
+    maxWaitingList: number | null
+    url: string
+}

--- a/src/utils/moodle-utils.ts
+++ b/src/utils/moodle-utils.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio'
 import { type FetchCookieImpl } from 'fetch-cookie'
 import { GraphQLError } from 'graphql'
+import moment from 'moment-timezone'
 import nodeFetch from 'node-fetch'
 
 export const MONTHS = {
@@ -78,4 +79,44 @@ export async function login(
     if ($('#loginerrormessage').length > 0) {
         throw new GraphQLError('Login failed')
     }
+}
+
+/**
+ * Parses a date like "1. Juli 2025, 16:00 - 18:00".
+ * @param {string} str
+ * @returns {Date}
+ */
+export function parseLocalDateTimeDuration(str: string): Date {
+    const match = str.match(
+        /(\d+)\. (\p{Letter}+) (\d+), (\d+):(\d+) - (\d+):(\d+)/u
+    )
+    if (!match) throw new Error(`Invalid date string: ${str}`)
+    const [, day, month, year, hour, minute] = match
+    const typedMonth = month as Month
+
+    // Create a date string and parse it in the Europe/Berlin time zone
+    const dateString = `${day}-${MONTHS[typedMonth]}-${year} ${hour}:${minute}`
+    const date = moment.tz(dateString, 'D-M-YYYY H:mm', 'Europe/Berlin')
+
+    // Convert to UTC and return a JavaScript Date
+    return date.utc().toDate()
+}
+
+/**
+ * Parses a date like "Donnerstag, 15. Juni 2023, 10:00".
+ * @param {string} str
+ * @returns {Date}
+ */
+export function parseLocalDateTime(str: string): Date {
+    const match = str.match(/, (\d+). (\p{Letter}+) (\d+), (\d+):(\d+)$/u)
+    if (!match) throw new Error(`Invalid date string: ${str}`)
+    const [, day, month, year, hour, minute] = match
+    const typedMonth = month as Month
+
+    // Create a date string and parse it in the Europe/Berlin time zone
+    const dateString = `${day}-${MONTHS[typedMonth]}-${year} ${hour}:${minute}`
+    const date = moment.tz(dateString, 'D-M-YYYY H:mm', 'Europe/Berlin')
+
+    // Convert to UTC and return a JavaScript Date
+    return date.utc().toDate()
 }


### PR DESCRIPTION
This pull request introduces a new feature to fetch and expose events from the student advisory service, along with refactoring date-parsing utilities to improve reusability. The most important changes include implementing the `studentAdvisoryEvents` query, adding a new GraphQL type for student advisory events, and centralizing date-parsing logic.

### New Feature: Student Advisory Events

* **New Query and Resolver**:
  - Added a `studentAdvisoryEvents` query to fetch student advisory service events. This includes a resolver in `src/resolvers.ts` and schema updates in `src/schema/schema.gql`. [[1]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR27) [[2]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR67) [[3]](diffhunk://#diff-61997d4ebaa4be9328c53a48386491a30642ec7fea39b8719e29dd0344badacaR22-R25)
  - Implemented the `studentAdvisoryEvents` function in `src/queries/studentAdvisory.ts`, which caches results for 12 hours and fetches data using a new scraping module.

* **New Scraping Module**:
  - Created `src/scraping/studentAdvisory.ts` to scrape event details from Moodle, including parsing event metadata (e.g., slots, waiting lists) and handling authentication.

* **New GraphQL Type**:
  - Added a `StudentAdvisoryEvent` type in `src/schema/types.gql` to describe event properties such as `id`, `title`, `date`, `slots`, and `waiting list`.

### Refactoring: Date Parsing Utilities

* **Centralized Parsing Logic**:
  - Moved and refactored date-parsing functions (`parseLocalDateTime` and `parseLocalDateTimeDuration`) into `src/utils/moodle-utils.ts` for reusability across scraping modules.

* **Refactored Existing Scrapers**:
  - Updated `src/scraping/careerService.ts` and `src/scraping/cl-event.ts` to use the centralized date-parsing utilities, improving code consistency and maintainability. [[1]](diffhunk://#diff-6bccf2cfe1b4f0d5a5d212fd22918b978a497291fd0474fb6263950bd36f90f9L4-L34) [[2]](diffhunk://#diff-6bccf2cfe1b4f0d5a5d212fd22918b978a497291fd0474fb6263950bd36f90f9L98-R76) [[3]](diffhunk://#diff-b317fd8a9233da1a4b538635198760d7e390635a4bb7d583a91763bbbf3ac51dL5-L11) [[4]](diffhunk://#diff-b317fd8a9233da1a4b538635198760d7e390635a4bb7d583a91763bbbf3ac51dL21-L39)