### PR TITLE
refactor(translate): optimize batch translation logic

### DIFF
--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -105,7 +105,7 @@ export async function translateMeals(
             ...meal,
             name: {
                 de: meal.name,
-                en: translations[meal.name],
+                en: translations[meal.name] || meal.name,
             },
             variants:
                 meal.variants !== undefined

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -1,68 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { cache } from '@/index'
-import type {
-    ExtendedMealData,
-    MealData,
-    PreFoodData,
-    TempMealData,
-} from '@/types/food'
-import translate, { type DeeplLanguages } from 'deepl'
+import type { ExtendedMealData, PreFoodData, TempMealData } from '@/types/food'
+import translate from 'deepl'
 
-const deeplEndpoint = 'https://api-free.deepl.com/v2/translate'
 const deeplApiKey = Bun.env.DEEPL_API_KEY || ''
 const enableDevTranslations =
     Bun.env.ENABLE_DEV_TRANSLATIONS === 'true' || false
 const disableFallbackWarning =
     Bun.env.DISABLE_FALLBACK_WARNING === 'true' || false
-const translationsCacheTTL = 60 * 60 * 24 * 14 // 14 days
 const isDev = Bun.env.NODE_ENV !== 'production'
-
-/**
- * Gets a translation from the cache or translates it using DeepL.
- * @param {String} text The text to translate
- * @param {String} target The target language
- * @returns {String} The translated text or the original text if DeepL is not configured or returns an error
- **/
-async function getTranslation(text: string, target: string): Promise<string> {
-    const cacheData = await cache.get(`food__${text}__${target}`)
-    if (cacheData !== undefined && cacheData !== null) {
-        return cacheData as string
-    } else {
-        const result = await translateText(text, target)
-        cache.set(`food__${text}__${target}`, result, translationsCacheTTL)
-        return result
-    }
-}
-
-/**
- * translates a text using DeepL.
- * @param {String} text The text to translate
- * @param {String} target The target language
- * @returns {String} The translated text
- * @throws {Error} If DeepL is not configured or returns an error
- */
-async function translateText(text: string, target: string): Promise<string> {
-    try {
-        const data = await translate({
-            text,
-            free_api: true,
-            target_lang: target as DeeplLanguages,
-            auth_key: deeplApiKey,
-            source_lang: 'DE',
-        })
-        return data.data.translations[0].text
-    } catch (err) {
-        console.error(err)
-        return isDev && !disableFallbackWarning ? `FALLBACK: ${text}` : text
-    }
-}
 
 /**
  * Brings the given meal plan into the correct format as if it was translated by DeepL.
  * @param {Object} meals The meal plan
  * @returns {Object} The translated meal plan
  **/
-function translateFallback(meals: PreFoodData[]): MealData[] {
+function translateMealsFallback(meals: PreFoodData[]): TempMealData[] {
     return meals.map((day: any) => {
         const meals = day.meals.map((meal: any) => {
             return {
@@ -110,55 +62,67 @@ export async function translateMeals(
         console.warn(
             'To enable DeepL in development mode, set ENABLE_DEV_TRANSLATIONS=true in your .env.local file.'
         )
-        return translateFallback(meals)
+        return translateMealsFallback(meals)
     }
 
-    if (deeplEndpoint.length === 0 || deeplApiKey === '') {
+    if (deeplApiKey === '') {
         console.warn('DeepL is not configured.')
         console.warn(
             'To enable DeepL, set the deeplApiKey in your .env.local file.'
         )
-        return translateFallback(meals)
+        return translateMealsFallback(meals)
     }
 
-    return (await Promise.all(
-        meals.map(async (day) => {
-            const meals = await Promise.all(
-                day.meals.map(async (meal) => {
-                    return {
-                        ...meal,
-                        name: {
-                            de: meal.name,
-                            en: await getTranslation(meal.name, 'EN-GB'),
-                        },
-                        variants:
-                            meal.variants !== undefined
-                                ? await Promise.all(
-                                      meal.variants.map(
-                                          async (variant: any) => {
-                                              return {
-                                                  ...variant,
-                                                  name: {
-                                                      de: variant.name,
-                                                      en: await getTranslation(
-                                                          variant.name,
-                                                          'EN-GB'
-                                                      ),
-                                                  },
-                                              }
-                                          }
-                                      )
-                                  )
-                                : [],
-                        originalLanguage: 'de',
-                    }
-                })
-            )
-
-            return {
-                ...day,
-                meals,
-            }
+    // creates a record of all meals (name as key) and undefined as value with all meals flattened including variants
+    const text: string[] = []
+    meals.forEach((day) => {
+        day.meals.forEach((meal) => {
+            text.push(meal.name)
+            meal.variants?.forEach((variant: any) => {
+                text.push(variant.name)
+            })
         })
-    )) as TempMealData[]
+    })
+
+    const result = await translate({
+        auth_key: deeplApiKey,
+        // @ts-expect-error: DeepL also accepts arrays of strings, but the type definition is not correct
+        text,
+        free_api: true,
+        target_lang: 'EN-GB',
+        source_lang: 'DE',
+        split_sentences: '1',
+    })
+
+    // map the result to the original meals using the index of the text array
+    const translations: Record<string, string> = {}
+    result.data.translations.forEach((translation, index) => {
+        translations[text[index]] = translation.text
+    })
+
+    return meals.map((day) => {
+        const meals = day.meals.map((meal) => ({
+            ...meal,
+            name: {
+                de: meal.name,
+                en: translations[meal.name],
+            },
+            variants:
+                meal.variants !== undefined
+                    ? meal.variants.map((variant: any) => ({
+                          ...variant,
+                          name: {
+                              de: variant.name,
+                              en: translations[variant.name] || variant.name,
+                          },
+                      }))
+                    : [],
+            originalLanguage: 'de',
+        }))
+
+        return {
+            ...day,
+            meals,
+        }
+    }) as TempMealData[]
 }

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -73,7 +73,7 @@ export async function translateMeals(
         return translateMealsFallback(meals)
     }
 
-    // creates a record of all meals (name as key) and undefined as value with all meals flattened including variants
+    // populates a flat array of all meal and variant names for translation
     const text: string[] = []
     meals.forEach((day) => {
         day.meals.forEach((meal) => {

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -84,21 +84,25 @@ export async function translateMeals(
         })
     })
 
-    const result = await translate({
-        auth_key: deeplApiKey,
-        // @ts-expect-error: DeepL also accepts arrays of strings, but the type definition is not correct
-        text,
-        free_api: true,
-        target_lang: 'EN-GB',
-        source_lang: 'DE',
-        split_sentences: '1',
-    })
-
-    // map the result to the original meals using the index of the text array
     const translations: Record<string, string> = {}
-    result.data.translations.forEach((translation, index) => {
-        translations[text[index]] = translation.text
-    })
+    try {
+        const result = await translate({
+            auth_key: deeplApiKey,
+            // @ts-expect-error: DeepL also accepts arrays of strings, but the type definition is not correct
+            text,
+            free_api: true,
+            target_lang: 'EN-GB',
+            source_lang: 'DE',
+            split_sentences: '1',
+        })
+
+        // map the result to the original meals using the index of the text array
+        result.data.translations.forEach((translation, index) => {
+            translations[text[index]] = translation.text
+        })
+    } catch (error) {
+        console.error('Error translating meals with DeepL:', error)
+    }
 
     return meals.map((day) => {
         const meals = day.meals.map((meal) => ({


### PR DESCRIPTION
Instead of spamming the deepl api and gettings 429s, batch it into one request.

----


This pull request refactors the translation logic in `src/utils/translation-utils.ts` to simplify the code and improve performance by removing redundant caching and consolidating translation calls. The key changes include removing the custom caching logic, replacing the `getTranslation` and `translateText` functions with a batch translation approach, and renaming functions for clarity.

### Refactoring and performance improvements:
* Removed the `getTranslation` and `translateText` functions, along with the associated caching logic, to simplify the code and reduce dependency on external caching (`[src/utils/translation-utils.tsL2-R17](diffhunk://#diff-7233b03ebaba96128acefd0eee3abb860f81b1af5ef031e262b0b44dc97095ddL2-R17)`).
* Implemented batch translation using DeepL's API to translate all meal names and variants in a single request, improving performance by reducing the number of API calls (`[src/utils/translation-utils.tsL113-R127](diffhunk://#diff-7233b03ebaba96128acefd0eee3abb860f81b1af5ef031e262b0b44dc97095ddL113-R127)`).

### Code clarity and consistency:
* Renamed `translateFallback` to `translateMealsFallback` for better alignment with its purpose and usage (`[[1]](diffhunk://#diff-7233b03ebaba96128acefd0eee3abb860f81b1af5ef031e262b0b44dc97095ddL2-R17)`, `[[2]](diffhunk://#diff-7233b03ebaba96128acefd0eee3abb860f81b1af5ef031e262b0b44dc97095ddL113-R127)`).
* Updated the `translateMeals` function to use the new batch translation logic and streamlined the mapping of translations back to the original meal data structure (`[src/utils/translation-utils.tsL113-R127](diffhunk://#diff-7233b03ebaba96128acefd0eee3abb860f81b1af5ef031e262b0b44dc97095ddL113-R127)`).