### PR TITLE
Track user emails on event mutations

### DIFF
--- a/src/db/migrations/0012_aspiring_wolfsbane.sql
+++ b/src/db/migrations/0012_aspiring_wolfsbane.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "app_announcements" ADD COLUMN "created_by_email" text;--> statement-breakpoint
+ALTER TABLE "app_announcements" ADD COLUMN "updated_by_email" text;--> statement-breakpoint
+ALTER TABLE "neulandEvents" ADD COLUMN "created_by_email" text;--> statement-breakpoint
+ALTER TABLE "neulandEvents" ADD COLUMN "updated_by_email" text;--> statement-breakpoint
+ALTER TABLE "university_sports" ADD COLUMN "created_by_email" text;--> statement-breakpoint
+ALTER TABLE "university_sports" ADD COLUMN "updated_by_email" text;

--- a/src/db/migrations/meta/0012_snapshot.json
+++ b/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,585 @@
+{
+    "id": "63a2b232-c0fe-41f6-9b83-137189134b72",
+    "prevId": "bedc7a0b-4cea-4091-8e8b-fc180bbfb759",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.app_announcements": {
+            "name": "app_announcements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "platform": {
+                    "name": "platform",
+                    "type": "app_platform[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_kind": {
+                    "name": "user_kind",
+                    "type": "user_kind[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "start_date_time": {
+                    "name": "start_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_date_time": {
+                    "name": "end_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "image_url": {
+                    "name": "image_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_by_email": {
+                    "name": "created_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_by_email": {
+                    "name": "updated_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.manual_cl_events": {
+            "name": "manual_cl_events",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start_date_time": {
+                    "name": "start_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_date_time": {
+                    "name": "end_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "organizer": {
+                    "name": "organizer",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "instagram": {
+                    "name": "instagram",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "event_url": {
+                    "name": "event_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.neulandEvents": {
+            "name": "neulandEvents",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_by_email": {
+                    "name": "created_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_by_email": {
+                    "name": "updated_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start_time": {
+                    "name": "start_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "end_time": {
+                    "name": "end_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "rrule": {
+                    "name": "rrule",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "idx_events_start_time": {
+                    "name": "idx_events_start_time",
+                    "columns": [
+                        {
+                            "expression": "start_time",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.room_reports": {
+            "name": "room_reports",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "room": {
+                    "name": "room",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "reason": {
+                    "name": "reason",
+                    "type": "room_report_reason",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "resolved_at": {
+                    "name": "resolved_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.university_sports": {
+            "name": "university_sports",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "campus": {
+                    "name": "campus",
+                    "type": "campus",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "weekday": {
+                    "name": "weekday",
+                    "type": "weekday",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "start_time": {
+                    "name": "start_time",
+                    "type": "time",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_time": {
+                    "name": "end_time",
+                    "type": "time",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "requires_registration": {
+                    "name": "requires_registration",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invitation_link": {
+                    "name": "invitation_link",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "e_mail": {
+                    "name": "e_mail",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sports_category": {
+                    "name": "sports_category",
+                    "type": "sports_category",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_by_email": {
+                    "name": "created_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_by_email": {
+                    "name": "updated_by_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.app_platform": {
+            "name": "app_platform",
+            "schema": "public",
+            "values": ["ANDROID", "IOS", "WEB", "WEB_DEV"]
+        },
+        "public.user_kind": {
+            "name": "user_kind",
+            "schema": "public",
+            "values": ["STUDENT", "EMPLOYEE", "GUEST"]
+        },
+        "public.room_report_reason": {
+            "name": "room_report_reason",
+            "schema": "public",
+            "values": [
+                "WRONG_DESCRIPTION",
+                "WRONG_LOCATION",
+                "NOT_EXISTING",
+                "MISSING",
+                "OTHER"
+            ]
+        },
+        "public.campus": {
+            "name": "campus",
+            "schema": "public",
+            "values": ["Ingolstadt", "Neuburg"]
+        },
+        "public.sports_category": {
+            "name": "sports_category",
+            "schema": "public",
+            "values": [
+                "Basketball",
+                "Soccer",
+                "Calisthenics",
+                "Dancing",
+                "StrengthTraining",
+                "Running",
+                "Jogging",
+                "Handball",
+                "Frisbee",
+                "Volleyball",
+                "Spikeball",
+                "FullBodyWorkout",
+                "Defense",
+                "Yoga",
+                "Meditation",
+                "Tennis",
+                "Badminton",
+                "Swimming",
+                "Waterpolo",
+                "Cycling",
+                "Climbing",
+                "Boxing",
+                "Kickboxing",
+                "MartialArts",
+                "TableTennis",
+                "Rowing",
+                "Baseball",
+                "Skateboarding",
+                "Parkour",
+                "Hockey",
+                "Hiking",
+                "Other"
+            ]
+        },
+        "public.weekday": {
+            "name": "weekday",
+            "schema": "public",
+            "values": [
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday"
+            ]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
             "when": 1743611960385,
             "tag": "0011_real_red_shift",
             "breakpoints": true
+        },
+        {
+            "idx": 12,
+            "version": "7",
+            "when": 1750548802425,
+            "tag": "0012_aspiring_wolfsbane",
+            "breakpoints": true
         }
     ]
 }

--- a/src/db/schema/appAnnouncements.ts
+++ b/src/db/schema/appAnnouncements.ts
@@ -35,4 +35,6 @@ export const appAnnouncements = pgTable('app_announcements', {
     image_url: text('image_url'),
     created_at: timestamp('created_at', { withTimezone: true }).notNull(),
     updated_at: timestamp('updated_at', { withTimezone: true }).notNull(),
+    created_by_email: text('created_by_email'),
+    updated_by_email: text('updated_by_email'),
 })

--- a/src/db/schema/neulandEvents.ts
+++ b/src/db/schema/neulandEvents.ts
@@ -15,6 +15,8 @@ export const neulandEvents = pgTable(
             .defaultNow()
             .notNull(),
         updated_at: timestamp('updated_at', { withTimezone: true }),
+        created_by_email: text('created_by_email'),
+        updated_by_email: text('updated_by_email'),
         start_time: timestamp('start_time', { withTimezone: true }),
         end_time: timestamp('end_time', { withTimezone: true }),
         rrule: text('rrule'),

--- a/src/db/schema/universitySports.ts
+++ b/src/db/schema/universitySports.ts
@@ -70,4 +70,6 @@ export const universitySports = pgTable('university_sports', {
     sports_category: sportsCategoryEnum('sports_category').notNull(),
     created_at: timestamp('created_at', { withTimezone: true }).notNull(),
     updated_at: timestamp('updated_at', { withTimezone: true }).notNull(),
+    created_by_email: text('created_by_email'),
+    updated_by_email: text('updated_by_email'),
 })

--- a/src/mutations/app-announcements/upsert.ts
+++ b/src/mutations/app-announcements/upsert.ts
@@ -12,7 +12,7 @@ export async function upsertAppAnnouncement(
         id: number | undefined
         input: AnnouncementInput
     },
-    contextValue: { jwtPayload?: { groups: string[] } }
+    contextValue: { jwtPayload?: { groups: string[]; email?: string } }
 ): Promise<{
     id: number
 }> {
@@ -30,6 +30,7 @@ export async function upsertAppAnnouncement(
         imageUrl,
     } = input
 
+    const email = contextValue.jwtPayload?.email ?? null
     let announcement
 
     if (id != null) {
@@ -49,6 +50,7 @@ export async function upsertAppAnnouncement(
                 url,
                 image_url: imageUrl,
                 updated_at: new Date(),
+                updated_by_email: email,
             })
             .where(eq(appAnnouncements.id, id))
 
@@ -73,6 +75,8 @@ export async function upsertAppAnnouncement(
                 image_url: imageUrl,
                 created_at: new Date(),
                 updated_at: new Date(),
+                created_by_email: email,
+                updated_by_email: email,
             })
 
             .returning({

--- a/src/mutations/neuland-events/upsert.ts
+++ b/src/mutations/neuland-events/upsert.ts
@@ -12,12 +12,13 @@ export async function upsertNeulandEvent(
         id: number | undefined
         input: NeulandEventInput
     },
-    contextValue: { jwtPayload?: { groups: string[] } }
+    contextValue: { jwtPayload?: { groups: string[]; email?: string } }
 ): Promise<{ id: number }> {
     const { title, description, location, startTime, endTime, rrule } = input
 
     checkAuthorization(contextValue, eventRole)
 
+    const email = contextValue.jwtPayload?.email ?? null
     let event
 
     if (id != null) {
@@ -33,6 +34,7 @@ export async function upsertNeulandEvent(
                 end_time: endTime,
                 rrule: rrule ?? null,
                 updated_at: new Date(),
+                updated_by_email: email,
             })
             .where(eq(neulandEvents.id, id))
             .returning({
@@ -52,6 +54,8 @@ export async function upsertNeulandEvent(
                 rrule: rrule ?? null,
                 created_at: new Date(),
                 updated_at: new Date(),
+                created_by_email: email,
+                updated_by_email: email,
             })
             .returning({
                 id: neulandEvents.id,

--- a/src/mutations/university-sports/upsert.ts
+++ b/src/mutations/university-sports/upsert.ts
@@ -12,7 +12,7 @@ export async function upsertUniversitySport(
         id: number | undefined
         input: UniversitySportInput
     },
-    contextValue: { jwtPayload?: { groups: string[] } }
+    contextValue: { jwtPayload?: { groups: string[]; email?: string } }
 ): Promise<{ id: number }> {
     const {
         title,
@@ -30,6 +30,7 @@ export async function upsertUniversitySport(
 
     checkAuthorization(contextValue, sportRole)
 
+    const email = contextValue.jwtPayload?.email ?? null
     let event
 
     if (id != null) {
@@ -50,6 +51,7 @@ export async function upsertUniversitySport(
                 e_mail: eMail ?? null,
                 sports_category: sportsCategory ?? null,
                 updated_at: new Date(),
+                updated_by_email: email,
             })
             .where(eq(universitySports.id, id))
             .returning({
@@ -74,6 +76,8 @@ export async function upsertUniversitySport(
                 sports_category: sportsCategory ?? null,
                 created_at: new Date(),
                 updated_at: new Date(),
+                created_by_email: email,
+                updated_by_email: email,
             })
             .returning({
                 id: universitySports.id,


### PR DESCRIPTION
## Summary
- add user email columns to app announcements, university sports and neuland events tables
- add migration for new columns
- include `email` from JWT in upsert mutations so inserts/updates record the email

## Testing
- `bun x drizzle-kit generate`
- `bun x eslint src/mutations/app-announcements/upsert.ts src/mutations/neuland-events/upsert.ts src/mutations/university-sports/upsert.ts src/db/schema/appAnnouncements.ts src/db/schema/universitySports.ts src/db/schema/neulandEvents.ts`

------
https://chatgpt.com/codex/tasks/task_b_685740aa3ab88326ab9e25c9e9bc32c0