### PR TITLE
feat: add app version deprecation support

### DIFF
--- a/src/db/migrations/0012_app_versions.sql
+++ b/src/db/migrations/0012_app_versions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "app_versions" (
+        "id" serial PRIMARY KEY NOT NULL,
+        "warning_version" text NOT NULL,
+        "deprecated_version" text NOT NULL,
+        "created_at" timestamp with time zone NOT NULL,
+        "updated_at" timestamp with time zone NOT NULL
+);

--- a/src/db/migrations/meta/0012_snapshot.json
+++ b/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,549 @@
+{
+    "id": "425ee53a-2c52-4a22-83ef-c1a2d3f1e384",
+    "prevId": "bedc7a0b-4cea-4091-8e8b-fc180bbfb759",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.app_announcements": {
+            "name": "app_announcements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "platform": {
+                    "name": "platform",
+                    "type": "app_platform[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_kind": {
+                    "name": "user_kind",
+                    "type": "user_kind[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "start_date_time": {
+                    "name": "start_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_date_time": {
+                    "name": "end_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "image_url": {
+                    "name": "image_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.manual_cl_events": {
+            "name": "manual_cl_events",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start_date_time": {
+                    "name": "start_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_date_time": {
+                    "name": "end_date_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "organizer": {
+                    "name": "organizer",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "instagram": {
+                    "name": "instagram",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "event_url": {
+                    "name": "event_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.neulandEvents": {
+            "name": "neulandEvents",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start_time": {
+                    "name": "start_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "end_time": {
+                    "name": "end_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "rrule": {
+                    "name": "rrule",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "idx_events_start_time": {
+                    "name": "idx_events_start_time",
+                    "columns": [
+                        {
+                            "expression": "start_time",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.room_reports": {
+            "name": "room_reports",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "room": {
+                    "name": "room",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "reason": {
+                    "name": "reason",
+                    "type": "room_report_reason",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "resolved_at": {
+                    "name": "resolved_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.university_sports": {
+            "name": "university_sports",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "title_de": {
+                    "name": "title_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_de": {
+                    "name": "description_de",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description_en": {
+                    "name": "description_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "campus": {
+                    "name": "campus",
+                    "type": "campus",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "weekday": {
+                    "name": "weekday",
+                    "type": "weekday",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "start_time": {
+                    "name": "start_time",
+                    "type": "time",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_time": {
+                    "name": "end_time",
+                    "type": "time",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "requires_registration": {
+                    "name": "requires_registration",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invitation_link": {
+                    "name": "invitation_link",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "e_mail": {
+                    "name": "e_mail",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sports_category": {
+                    "name": "sports_category",
+                    "type": "sports_category",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.app_platform": {
+            "name": "app_platform",
+            "schema": "public",
+            "values": ["ANDROID", "IOS", "WEB", "WEB_DEV"]
+        },
+        "public.user_kind": {
+            "name": "user_kind",
+            "schema": "public",
+            "values": ["STUDENT", "EMPLOYEE", "GUEST"]
+        },
+        "public.room_report_reason": {
+            "name": "room_report_reason",
+            "schema": "public",
+            "values": [
+                "WRONG_DESCRIPTION",
+                "WRONG_LOCATION",
+                "NOT_EXISTING",
+                "MISSING",
+                "OTHER"
+            ]
+        },
+        "public.campus": {
+            "name": "campus",
+            "schema": "public",
+            "values": ["Ingolstadt", "Neuburg"]
+        },
+        "public.sports_category": {
+            "name": "sports_category",
+            "schema": "public",
+            "values": [
+                "Basketball",
+                "Soccer",
+                "Calisthenics",
+                "Dancing",
+                "StrengthTraining",
+                "Running",
+                "Jogging",
+                "Handball",
+                "Frisbee",
+                "Volleyball",
+                "Spikeball",
+                "FullBodyWorkout",
+                "Defense",
+                "Yoga",
+                "Meditation",
+                "Tennis",
+                "Badminton",
+                "Swimming",
+                "Waterpolo",
+                "Cycling",
+                "Climbing",
+                "Boxing",
+                "Kickboxing",
+                "MartialArts",
+                "TableTennis",
+                "Rowing",
+                "Baseball",
+                "Skateboarding",
+                "Parkour",
+                "Hockey",
+                "Hiking",
+                "Other"
+            ]
+        },
+        "public.weekday": {
+            "name": "weekday",
+            "schema": "public",
+            "values": [
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday"
+            ]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
             "when": 1743611960385,
             "tag": "0011_real_red_shift",
             "breakpoints": true
+        },
+        {
+            "idx": 12,
+            "version": "7",
+            "when": 1750548759867,
+            "tag": "0012_app_versions",
+            "breakpoints": true
         }
     ]
 }

--- a/src/db/schema/appVersions.ts
+++ b/src/db/schema/appVersions.ts
@@ -1,0 +1,9 @@
+import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const appVersions = pgTable('app_versions', {
+    id: serial('id').primaryKey(),
+    warning_version: text('warning_version').notNull(),
+    deprecated_version: text('deprecated_version').notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).notNull(),
+})

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 import * as appAnnouncements from '@/db/schema/appAnnouncements'
+import * as appVersions from '@/db/schema/appVersions'
 import * as manualClEvents from '@/db/schema/manualClEvents'
 import * as roomReports from '@/db/schema/roomReports'
 import * as universitySports from '@/db/schema/universitySports'
@@ -9,5 +10,6 @@ export default {
     ...universitySports,
     ...roomReports,
     ...manualClEvents,
+    ...appVersions,
     ...deleteManualClEvent,
 }

--- a/src/mutations/app-versions/upsert.ts
+++ b/src/mutations/app-versions/upsert.ts
@@ -1,0 +1,38 @@
+import { db } from '@/db'
+import { appVersions } from '@/db/schema/appVersions'
+import { adminRole, checkAuthorization } from '@/utils/auth-utils'
+import { eq } from 'drizzle-orm'
+
+export async function upsertAppVersion(
+    _: unknown,
+    { id, input }: { id: number | undefined; input: AppVersionInfoInput },
+    contextValue: { jwtPayload?: { groups: string[] } }
+): Promise<{ id: number }> {
+    const { warningVersion, deprecatedVersion } = input
+    checkAuthorization(contextValue, adminRole)
+
+    let version
+    if (id != null) {
+        ;[version] = await db
+            .update(appVersions)
+            .set({
+                warning_version: warningVersion,
+                deprecated_version: deprecatedVersion,
+                updated_at: new Date(),
+            })
+            .where(eq(appVersions.id, id))
+            .returning({ id: appVersions.id })
+    } else {
+        ;[version] = await db
+            .insert(appVersions)
+            .values({
+                warning_version: warningVersion,
+                deprecated_version: deprecatedVersion,
+                created_at: new Date(),
+                updated_at: new Date(),
+            })
+            .returning({ id: appVersions.id })
+    }
+
+    return { id: version.id }
+}

--- a/src/queries/appVersions.ts
+++ b/src/queries/appVersions.ts
@@ -1,0 +1,17 @@
+import { db } from '@/db'
+import { appVersions } from '@/db/schema/appVersions'
+
+export async function appVersionsQuery(): Promise<AppVersionInfo | null> {
+    const data = await db.select().from(appVersions).limit(1)
+    if (data.length === 0) {
+        return null
+    }
+    const version = data[0]
+    return {
+        id: version.id,
+        warningVersion: version.warning_version,
+        deprecatedVersion: version.deprecated_version,
+        createdAt: version.created_at,
+        updatedAt: version.updated_at,
+    }
+}

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -14,6 +14,7 @@ import {
 
 import { deleteAppAnnouncement } from './mutations/app-announcements/delete'
 import { upsertAppAnnouncement } from './mutations/app-announcements/upsert'
+import { upsertAppVersion } from './mutations/app-versions/upsert'
 import { deleteManualClEvent } from './mutations/manual-cl-events/delete'
 import { upsertManualClEvent } from './mutations/manual-cl-events/upsert'
 import { deleteNeulandEvent } from './mutations/neuland-events/delete'
@@ -21,6 +22,7 @@ import { upsertNeulandEvent } from './mutations/neuland-events/upsert'
 import { createRoomReport } from './mutations/room-reports/create'
 import { resolveRoomReport } from './mutations/room-reports/resolve'
 import { appAnnouncementsQuery } from './queries/appAnnouncements'
+import { appVersionsQuery } from './queries/appVersions'
 import { careerServiceEvents } from './queries/careerService'
 import { neulandEventsQuery } from './queries/neulandEvents'
 import { roomReportsQuery } from './queries/roomReports'
@@ -70,6 +72,7 @@ export const resolvers = {
         universitySports: sports,
         roomReports: roomReportsQuery,
         neulandEvents: neulandEventsQuery,
+        appVersionInfo: appVersionsQuery,
     },
     Mutation: {
         deleteUniversitySport,
@@ -82,6 +85,7 @@ export const resolvers = {
         deleteManualClEvent,
         deleteNeulandEvent,
         upsertNeulandEvent,
+        upsertAppVersion,
     },
     LocalTime: LocalEndTimeResolver,
     DateTime: DateTimeResolver,

--- a/src/schema/inputs.gql
+++ b/src/schema/inputs.gql
@@ -197,3 +197,17 @@ input NeulandEventInput {
     """
     rrule: String
 }
+
+"""
+Input type for setting the app version deprecation information.
+"""
+input AppVersionInfoInput {
+    """
+    Version where an update warning should be displayed
+    """
+    warningVersion: String!
+    """
+    Version that is no longer supported
+    """
+    deprecatedVersion: String!
+}

--- a/src/schema/schema.gql
+++ b/src/schema/schema.gql
@@ -43,6 +43,10 @@ type Query {
     Get all events by Neuland Ingolstadt e.V.
     """
     neulandEvents: [NeulandEvent!]!
+    """
+    Get information about supported app versions.
+    """
+    appVersionInfo: AppVersionInfo
 }
 
 """
@@ -92,4 +96,8 @@ type Mutation {
     Delete a Neuland event by ID. Note: This mutation is only available for authenticated users.
     """
     deleteNeulandEvent(id: ID!): Boolean
+    """
+    Set the supported app versions. Note: This mutation is only available for authenticated users.
+    """
+    upsertAppVersion(id: ID, input: AppVersionInfoInput!): UpsertResponse
 }

--- a/src/schema/types.gql
+++ b/src/schema/types.gql
@@ -599,3 +599,20 @@ type NeulandEvent {
     """
     rrule: String
 }
+
+"""
+Information about deprecated app versions.
+"""
+type AppVersionInfo {
+    id: ID!
+    """
+    Version where an update warning should be shown
+    """
+    warningVersion: String!
+    """
+    Version that is no longer supported
+    """
+    deprecatedVersion: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+}

--- a/src/types/appVersion.d.ts
+++ b/src/types/appVersion.d.ts
@@ -1,0 +1,12 @@
+interface AppVersionInfo {
+    id: number
+    warningVersion: string
+    deprecatedVersion: string
+    createdAt: Date
+    updatedAt: Date
+}
+
+interface AppVersionInfoInput {
+    warningVersion: string
+    deprecatedVersion: string
+}


### PR DESCRIPTION
## Summary
- store app version info in new `app_versions` table
- allow admins to manage app version info via GraphQL mutation
- expose the current info through new `appVersionInfo` query
- wire up resolvers and schema for the new feature

## Testing
- `npx eslint .` *(fails: npm registry blocked)*
