### PR TITLE
feat: add library seat availability queries

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -23,7 +23,7 @@ import { resolveRoomReport } from './mutations/room-reports/resolve'
 import { appAnnouncementsQuery } from './queries/appAnnouncements'
 import { auditLogQuery } from './queries/auditLog'
 import { careerServiceEvents } from './queries/careerService'
-import { librarySeatRooms, librarySeats } from './queries/librarySeats'
+import { librarySeatDetails, libraryStatus } from './queries/libraryStatus'
 import { neulandEventsQuery } from './queries/neulandEvents'
 import { roomReportsQuery } from './queries/roomReports'
 import { studentCounsellingEvents } from './queries/studentCounselling'
@@ -72,8 +72,8 @@ export const resolvers = {
         universitySports: sports,
         roomReports: roomReportsQuery,
         neulandEvents: neulandEventsQuery,
-        librarySeats,
-        librarySeatRooms,
+        libraryStatus,
+        librarySeatDetails,
         auditLog: auditLogQuery,
     },
     Mutation: {

--- a/src/schema/schema.gql
+++ b/src/schema/schema.gql
@@ -46,11 +46,11 @@ type Query {
     """
     Get the amount of seats in the library grouped by type and how many are currently available.
     """
-    librarySeats: LibrarySeatInfo!
+    libraryStatus: LibrarySeatInfo!
     """
     Get all library seats with availability information and location.
     """
-    librarySeatRooms: [LibrarySeatRoom!]!
+    librarySeatDetails: [LibrarySeatDetail!]!
     """
     Get the audit log entries. Note: This query is only available for authenticated admin users.
     """

--- a/src/schema/types.gql
+++ b/src/schema/types.gql
@@ -669,7 +669,7 @@ type LibrarySeatInfo {
 """
 Details for a single seat in the library.
 """
-type LibrarySeatRoom {
+type LibrarySeatDetail {
     """
     Identifier of the seat
     """

--- a/src/types/librarySeats.d.ts
+++ b/src/types/librarySeats.d.ts
@@ -9,7 +9,7 @@ interface LibrarySeatInfo {
     groupWorkRoom: LibrarySeatStatus
 }
 
-interface LibrarySeatRoom {
+interface LibrarySeatDetail {
     roomId: string
     available: boolean
     location: string


### PR DESCRIPTION
This pull request introduces new functionality to fetch and expose library seat availability data through GraphQL queries. The changes include implementing data fetching logic, integrating it into the resolver layer, and extending the GraphQL schema to support the new queries and types.

### Backend functionality for fetching library seat data:
* [`src/queries/libraryStatus.ts`](diffhunk://#diff-e7e3659b2f9d2f2cb526244889d2cf47d6f5f6ba82eb1921b45e3f9a42abd40aR1-R96): Added functions `libraryStatus` and `librarySeatDetails` to fetch and process library seat availability data from a remote endpoint, with caching for improved performance.

### Integration into GraphQL resolvers:
* [`src/resolvers.ts`](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR26): Registered the `libraryStatus` and `librarySeatDetails` queries in the resolver layer for GraphQL. [[1]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR26) [[2]](diffhunk://#diff-f25aebc206e96407bd5d65c2ec780b48aa1f7f04efb1b9c7ddd41c617f87b51aR75-R76)

### GraphQL schema extension:
* [`src/schema/schema.gql`](diffhunk://#diff-61997d4ebaa4be9328c53a48386491a30642ec7fea39b8719e29dd0344badacaR47-R54): Added `libraryStatus` and `librarySeatDetails` queries to the schema, providing descriptions for their purpose.
* [`src/schema/types.gql`](diffhunk://#diff-06b281c004c979b2b71c3e6228072b18d8409a07dfb1c7604d470b6cda350a73R636-R689): Defined new types `LibrarySeatStatus`, `LibrarySeatInfo`, and `LibrarySeatDetail` to structure the data returned by the new queries.